### PR TITLE
Enable Language Server for Nix and configure it for VS Code

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,6 +98,24 @@
         "url": "https://flakehub.com/f/edolstra/flake-compat/1.0.1.tar.gz"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flakeCompat": {
       "flake": false,
       "locked": {
@@ -152,6 +170,26 @@
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/nix-community/naersk/0.1.332.tar.gz"
+      }
+    },
+    "nil": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1701225372,
+        "narHash": "sha256-QSiFeEmTzAIIiCtUaMesu7wi7bvfHuFzPMQpOKMt4Lo=",
+        "owner": "oxalica",
+        "repo": "nil",
+        "rev": "0031eb4343fd4672742fd6ff839da9b4f5120646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "nil",
+        "type": "github"
       }
     },
     "nixos-hardware": {
@@ -217,6 +255,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1696725822,
+        "narHash": "sha256-B7uAOS7TkLlOg1aX01rQlYbydcyB6ZnLJSfaYbKVww8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5aabb5780a11c500981993d49ee93cfa6df9307b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1703467016,
         "narHash": "sha256-/5A/dNPhbQx/Oa2d+Get174eNI3LERQ7u6WTWOlR1eQ=",
         "rev": "d02d818f22c777aa4e854efc3242ec451e5d462a",
@@ -229,7 +283,7 @@
         "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A.tar.gz"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1702539185,
         "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
@@ -250,8 +304,9 @@
         "alejandra": "alejandra",
         "fh": "fh",
         "home-manager": "home-manager",
+        "nil": "nil",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "sops-nix": "sops-nix"
       }
@@ -290,9 +345,34 @@
         "type": "github"
       }
     },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "nil",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nil",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1696817516,
+        "narHash": "sha256-Xt9OY4Wnk9/vuUfA0OHFtmSlaen5GyiS9msgwOz3okI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c0df7f2a856b5ff27a3ce314f6d7aacf5fda546f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -306,6 +386,21 @@
       "original": {
         "owner": "Mic92",
         "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Language Server for Nix expression.
+    # https://github.com/oxalica/nil
+    # nil is not the only one Language Server available for Nix. There are also:
+    # https://github.com/nix-community/nixd
+    # https://github.com/nix-community/rnix-lsp
+    nil.url = "github:oxalica/nil";
+
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
 
     sops-nix.url = "github:Mic92/sops-nix";
@@ -38,6 +45,7 @@
     alejandra,
     fh,
     home-manager,
+    nil,
     nixos-hardware,
     nixpkgs,
     nixpkgs-unstable,
@@ -70,6 +78,9 @@
         }
         {
           environment.systemPackages = [fh.packages.${system}.default];
+        }
+        {
+          environment.systemPackages = [nil.packages.${system}.default];
         }
         ./nixos/hosts/l390/configuration.nix
         # Declare home-manager as a NixOS module, so that all the home-manager

--- a/flake.nix
+++ b/flake.nix
@@ -76,12 +76,6 @@
         {
           environment.systemPackages = [alejandra.defaultPackage.${system}];
         }
-        {
-          environment.systemPackages = [fh.packages.${system}.default];
-        }
-        {
-          environment.systemPackages = [nil.packages.${system}.default];
-        }
         ./nixos/hosts/l390/configuration.nix
         # Declare home-manager as a NixOS module, so that all the home-manager
         # configuration will be deployed automatically when executing:
@@ -99,7 +93,7 @@
       # Nix modules automatically receive as inputs: config, lib, modulesPath,
       # options, pkgs. If you want to pass additional inputs to Nix modules,
       # you need to do it explicitly using these specialArgs.
-      specialArgs = {inherit allowed-unfree-packages inputs nixos-hardware nixpkgs sops-nix user;};
+      specialArgs = {inherit allowed-unfree-packages fh inputs nil nixos-hardware nixpkgs sops-nix user;};
     };
 
     nixosConfigurations."x220-nixos" = nixpkgs.lib.nixosSystem rec {
@@ -108,9 +102,6 @@
       modules = [
         {
           environment.systemPackages = [alejandra.defaultPackage.${system}];
-        }
-        {
-          environment.systemPackages = [fh.packages.${system}.default];
         }
         ./nixos/hosts/x220/configuration.nix
         home-manager.nixosModules.home-manager
@@ -122,7 +113,7 @@
         }
       ];
 
-      specialArgs = {inherit allowed-unfree-packages inputs nixos-hardware nixpkgs sops-nix user;};
+      specialArgs = {inherit allowed-unfree-packages fh inputs nil nixos-hardware nixpkgs sops-nix user;};
     };
 
     # Standalone home-manager configuration entrypoint

--- a/home-manager/modules/vscode.nix
+++ b/home-manager/modules/vscode.nix
@@ -272,13 +272,18 @@ in {
         # GitLens settings
         # https://help.gitkraken.com/gitlens/gitlens-settings/
         "gitlens.ai.experimental.provider" = "openai";
-        # https://github.com/nix-community/vscode-nix-ide
+        # Configure vscode-nix-ide to use nil as the language server for Nix expressions.
         # https://github.com/oxalica/nil?tab=readme-ov-file#vscodevscodium-with-nix-ide
-        "nix.enableLanguageServer" = true; # Enable LSP
-        "nix.serverPath" = "nil"; # The path to the LSP server executable
+        "nix.enableLanguageServer" = true;
+        "nix.serverPath" = "nil";
         "nix.serverSettings" = {
           nil = {
-            formatting = {command = ["alejandra"];};
+            diagnostics = {
+              ignored = ["unused_binding" "unused_with"];
+            };
+            formatting = {
+              command = ["alejandra"];
+            };
           };
         };
         # "security.workspace.trust.untrustedFiles" = "open";

--- a/home-manager/modules/vscode.nix
+++ b/home-manager/modules/vscode.nix
@@ -149,6 +149,7 @@ in {
         github.vscode-github-actions
         github.vscode-pull-request-github
         jdinhlife.gruvbox # Gruvbox theme
+        jnoortheen.nix-ide # Nix language support with formatting and error report
         kamadorueda.alejandra # Nix formatter
         mechatroner.rainbow-csv
         mhutchie.git-graph
@@ -271,6 +272,15 @@ in {
         # GitLens settings
         # https://help.gitkraken.com/gitlens/gitlens-settings/
         "gitlens.ai.experimental.provider" = "openai";
+        # https://github.com/nix-community/vscode-nix-ide
+        # https://github.com/oxalica/nil?tab=readme-ov-file#vscodevscodium-with-nix-ide
+        "nix.enableLanguageServer" = true; # Enable LSP
+        "nix.serverPath" = "nil"; # The path to the LSP server executable
+        "nix.serverSettings" = {
+          nil = {
+            formatting = {command = ["alejandra"];};
+          };
+        };
         # "security.workspace.trust.untrustedFiles" = "open";
         "turboConsoleLog.includeFileNameAndLineNum" = false;
         # Open all NEW VS Code windows in full screen mode. The first window will

--- a/nixos/hosts/l390/configuration.nix
+++ b/nixos/hosts/l390/configuration.nix
@@ -1,8 +1,10 @@
 {
   allowed-unfree-packages,
   config,
+  fh,
   inputs,
   lib,
+  nil,
   nixos-hardware,
   pkgs,
   sops-nix,
@@ -13,6 +15,12 @@
     # There is no Nix module for the ThinkPad L390. Maybe find a similar model.
     # nixos-hardware.nixosModules.lenovo-thinkpad-l390
     ./hardware-configuration.nix
+    {
+      environment.systemPackages = [fh.packages.x86_64-linux.default];
+    }
+    {
+      environment.systemPackages = [nil.packages.x86_64-linux.default];
+    }
     ../../modules/bluetooth.nix
     ../../modules/fonts.nix
     ../../modules/nix.nix

--- a/nixos/hosts/x220/configuration.nix
+++ b/nixos/hosts/x220/configuration.nix
@@ -1,8 +1,10 @@
 {
   allowed-unfree-packages,
   config,
+  fh,
   inputs,
   lib,
+  nil,
   nixos-hardware,
   pkgs,
   sops-nix,
@@ -12,6 +14,12 @@
   imports = [
     nixos-hardware.nixosModules.lenovo-thinkpad-x220
     ./hardware-configuration.nix
+    {
+      environment.systemPackages = [fh.packages.x86_64-linux.default];
+    }
+    {
+      environment.systemPackages = [nil.packages.x86_64-linux.default];
+    }
     ../../modules/bluetooth.nix
     ../../modules/fonts.nix
     ../../modules/nix.nix


### PR DESCRIPTION
This PR configures the [nil](https://github.com/oxalica/nil) language server and the [vscode-nix-ide](https://github.com/nix-community/vscode-nix-ide) VS Code extension.